### PR TITLE
Door toggle

### DIFF
--- a/prism_project/core/models.py
+++ b/prism_project/core/models.py
@@ -15,3 +15,11 @@ class Door(models.Model):
             return "CLOSED as of %s" % time
         else:
             return "DOOR STATUS UNKNOWN"
+    
+    def status(self):
+        if self.is_open == 1:
+            return "open"
+        elif self.is_open == 0:
+            return "closed"
+        else:
+            return "UNKNOWN"

--- a/prism_project/core/urls.py
+++ b/prism_project/core/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='home'),
+    path('door-toggle', views.doorToggle, name="door-toggle")
 ]

--- a/prism_project/core/views.py
+++ b/prism_project/core/views.py
@@ -1,5 +1,8 @@
+from django.utils import timezone
 from django.shortcuts import render
+from django.http import HttpResponseRedirect
 from django.apps import apps
+
 
 # Load model dynamically to avoid circular import issues
 DoorModel = apps.get_model('core', 'Door')
@@ -15,3 +18,19 @@ def index(request): # homepage
         'door': DoorModel.objects.order_by('-date_modified').first(),
     }
     return render(request, 'core/index.html', context)
+
+def doorToggle(request):
+    if request.method == 'POST':
+        door = DoorModel.objects.order_by('-date_modified').first()
+    
+    # Open door if closed, close if open, close if unknown
+        if door.is_open == 1:
+            door.is_open = 0
+        elif door.is_open == 0:
+            door.is_open = 1
+        else:
+            door.is_open = 0
+        door.date_modified = timezone.now()
+        door.save()
+
+    return HttpResponseRedirect('/')

--- a/prism_project/pages/views.py
+++ b/prism_project/pages/views.py
@@ -3,6 +3,7 @@ from django.apps import apps
 
 # Load model dynamically to avoid circular import issues
 PageModel = apps.get_model('pages', "Page")
+DoorModel = apps.get_model('core', 'Door')
 
 # Add views here. Add by adding new function def subpage(request): return render(request, html file path, context)
 # Add html not in a file using HttpResponse(html)
@@ -11,13 +12,15 @@ PageModel = apps.get_model('pages', "Page")
 def index(request): # ./pages/
     context = {
         'pages': PageModel.objects.order_by('-date_modified'),
-        'finalPage': PageModel.objects.order_by('-date_modified').last()
+        'finalPage': PageModel.objects.order_by('-date_modified').last(),
+        'door': DoorModel.objects.order_by('-date_modified').first(),
     }
     return render(request, 'pages/index.html', context)
 
 def page_viewer(request, title):
     context = {
-        'page': PageModel.objects.get(title=title.lower())
+        'page': PageModel.objects.get(title=title.lower()),
+        'door': DoorModel.objects.order_by('-date_modified').first(),
     }
     #return render(request, 'pages/x.html', context)
     return render(request, 'pages/page-view.html', context)

--- a/prism_project/static/css/main.css
+++ b/prism_project/static/css/main.css
@@ -107,7 +107,7 @@
             text-decoration: none;
         }
 
-        input, textarea {
+        .user-login-input {
             background: #fff;
             border: 1px solid rgba(0,0,0,.35);
             font-size: 1em;
@@ -115,7 +115,6 @@
             padding: .35em .5em;
             position: relative;
             display: inline-block;
-            max-width: calc(100% - 6px - .5em);
         }
 
         p {
@@ -175,6 +174,32 @@
             margin-bottom: 1em;
         }
 
+        .nav-status {
+            background-color: rgb(255, 255, 204);
+            margin-right: 1em;
+            border: 0.5px solid var(--eBlue);
+        }
+        
+        .nav-status:hover {
+            background-color: rgb(255, 255, 144);
+        }
+
+        .nav-status.open {
+            background-color: rgb(204, 255, 204);
+        }
+
+        .nav-status.open:hover {
+            background-color: rgb(144, 255, 144);
+        }
+
+        .nav-status.closed {
+            background-color: rgb(255, 204, 204);
+        }
+
+        .nav-status.closed:hover {
+            background-color: rgb(255, 144, 144);
+        }
+
         .bg-eBlue {
         background-color: var(--eBlue);
         }
@@ -195,7 +220,6 @@
             width: 48px;
         }
 
-        
         #sidenav li {
             margin: 0;
         }
@@ -242,6 +266,16 @@
             border-radius: 10px;
 
             margin-bottom: 1em;
+        }
+
+        .door-status-button {
+            margin-bottom: 1em;
+            background-color: #dddddd86;
+        }
+
+        .door-status-button:hover {
+            background-color: #dddddd;
+            border: 0.5px solid var(--eBlue);
         }
 
     /* ------------------------------------------------------

--- a/prism_project/templates/base.html
+++ b/prism_project/templates/base.html
@@ -57,10 +57,8 @@
 
                         <!-- Navbar Right Side -->
                         <nav class="navbar-nav">
+                            {% block 'door-status' %}{% endblock 'door-status' %}
                             {% if user.is_active %}
-                                {% if perms.core.change_door %}
-                                    {% block 'door-status' %}{% endblock 'door-status' %}
-                                {% endif %}
                                 <span style="color:white;">Welcome, <a id="user-link" class="nav-item nav-link" href="{% url 'profile' %}">{{ user.get_first_name }}</a></span>
                                 {% if user.is_staff %}
                                     <a class="nav-item nav-link" href="{% url 'admin:index' %}">Admin</a>

--- a/prism_project/templates/base.html
+++ b/prism_project/templates/base.html
@@ -58,6 +58,9 @@
                         <!-- Navbar Right Side -->
                         <nav class="navbar-nav">
                             {% if user.is_active %}
+                                {% if perms.core.change_door %}
+                                    {% block 'door-status' %}{% endblock 'door-status' %}
+                                {% endif %}
                                 <span style="color:white;">Welcome, <a id="user-link" class="nav-item nav-link" href="{% url 'profile' %}">{{ user.get_first_name }}</a></span>
                                 {% if user.is_staff %}
                                     <a class="nav-item nav-link" href="{% url 'admin:index' %}">Admin</a>

--- a/prism_project/templates/core/index.html
+++ b/prism_project/templates/core/index.html
@@ -35,6 +35,17 @@
             <div id="door-status-indicator">
                 <p>PRISM is located in 'SoHo', room 335 of the Cohen University Center. Come stop on by!</p>
                 <p>SoHo is currently <span id="door-status">{{ door }}</span></p>
+                
+                {% if perms.core.change_door %}
+                    <form method="post" action="/door-toggle">
+                        {% csrf_token %}
+                        {% if door.status == "open" %}
+                            <input type="submit" class="door-status-button btn" value="Close SoHo"/>
+                        {% else %}
+                            <input type="submit" class="door-status-button btn" value="Open SoHo"/>
+                        {% endif %}
+                    </form>
+                {% endif %}
             </div>
             <ul id="sidenav" class="list-group d-none d-md-block">
                 <li class="list-group-item">
@@ -57,7 +68,6 @@
                 </li>
             </ul> <!-- End sidenav-->
         </div> <!-- End column -->
-
     </div> <!-- End row -->
 
     <div class="row">

--- a/prism_project/templates/pages/page-view.html
+++ b/prism_project/templates/pages/page-view.html
@@ -3,6 +3,8 @@
 
 {% block title %}PRISM - {{ page.pretty_title }}{% endblock title %}
 
+{% block description %}{{ page.description }}{% endblock description %}
+
 {% block 'page-content' %}
     <h3>{{ page.pretty_title }}</h3>
     

--- a/prism_project/templates/pages/pages-base.html
+++ b/prism_project/templates/pages/pages-base.html
@@ -3,9 +3,22 @@
 
 {% load static %}
 
-{% block title %} PRISM - Page Directory {% endblock title %}
+{% block title %}PRISM - Page Directory{% endblock title %}
 
 {% block description %}A list of all currently available pages.{% endblock description %}
+
+{% block 'door-status' %}
+    <form method="post" action="/door-toggle">
+        {% csrf_token %}
+        {% if door.status == "open" %}
+            <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
+        {% elif door.status == "closed" %}
+            <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
+        {% else %}
+            <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
+        {% endif %}
+    </form>
+{% endblock 'door-status' %}
 
 <div class="row">
     <div class="col-12">

--- a/prism_project/templates/pages/pages-base.html
+++ b/prism_project/templates/pages/pages-base.html
@@ -8,16 +8,26 @@
 {% block description %}A list of all currently available pages.{% endblock description %}
 
 {% block 'door-status' %}
-    <form method="post" action="/door-toggle">
-        {% csrf_token %}
+    {% if user.is_active and perms.core.change_door %}
+        <form method="post" action="/door-toggle">
+            {% csrf_token %}
+            {% if door.status == "open" %}
+                <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
+            {% elif door.status == "closed" %}
+                <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
+            {% else %}
+                <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
+            {% endif %}
+        </form>
+    {% else %}
         {% if door.status == "open" %}
-            <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
+            <span class="nav-item btn nav-status open">SoHo is {{ door.status }}</span>
         {% elif door.status == "closed" %}
-            <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
+            <span class="nav-item btn nav-status closed">SoHo is {{ door.status }}</span>
         {% else %}
-            <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
+            <span class="nav-item btn nav-status">SoHo is {{ door.status }}</span>
         {% endif %}
-    </form>
+    {% endif %}
 {% endblock 'door-status' %}
 
 <div class="row">

--- a/prism_project/templates/registration/login.html
+++ b/prism_project/templates/registration/login.html
@@ -21,17 +21,17 @@
         {% csrf_token %}
         <table>
         <tr>
-            <td>{{ form.username.label_tag }}</td>
+            <td>{{ form.username.label_tag }}</td> 
             <td>{{ form.username }}</td>
         </tr>
         <tr>
-            <td>{{ form.password.label_tag }}</td>
+            <td>{{ form.password.label_tag }}</td> 
             <td>{{ form.password }}</td>
         </tr>
         </table>
 
-        <input type="submit" value="login">
-        <input type="hidden" name="next" value="{{ next }}">
+        <input class="user-login-input" type="submit" value="login">
+        <input class="user-login-input" type="hidden" name="next" value="{{ next }}">
     </form>
 
     <br>

--- a/prism_project/templates/updates/index.html
+++ b/prism_project/templates/updates/index.html
@@ -1,9 +1,22 @@
 <!-- Django code to add this html to ../base.html -->
 {% extends "base.html" %}
 
-{% block title %} PRISM - Updates Directory {% endblock title %}
+{% block title %}PRISM - Updates Directory{% endblock title %}
 
-{% block description %}Directory of all currently available updates of days past.{% endblock description%}
+{% block description %}Directory of all currently available updates of days past.{% endblock description %}
+
+{% block 'door-status' %}
+    <form method="post" action="/door-toggle">
+        {% csrf_token %}
+        {% if door.status == "open" %}
+            <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
+        {% elif door.status == "closed" %}
+            <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
+        {% else %}
+            <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
+        {% endif %}
+    </form>
+{% endblock 'door-status' %}
 
 <div class="row">
     <div class="col-12">

--- a/prism_project/templates/updates/index.html
+++ b/prism_project/templates/updates/index.html
@@ -6,16 +6,26 @@
 {% block description %}Directory of all currently available updates of days past.{% endblock description %}
 
 {% block 'door-status' %}
-    <form method="post" action="/door-toggle">
-        {% csrf_token %}
+    {% if user.is_active and perms.core.change_door %}
+        <form method="post" action="/door-toggle">
+            {% csrf_token %}
+            {% if door.status == "open" %}
+                <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
+            {% elif door.status == "closed" %}
+                <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
+            {% else %}
+                <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
+            {% endif %}
+        </form>
+    {% else %}
         {% if door.status == "open" %}
-            <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
+            <span class="nav-item btn nav-status open">SoHo is {{ door.status }}</span>
         {% elif door.status == "closed" %}
-            <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
+            <span class="nav-item btn nav-status closed">SoHo is {{ door.status }}</span>
         {% else %}
-            <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
+            <span class="nav-item btn nav-status">SoHo is {{ door.status }}</span>
         {% endif %}
-    </form>
+    {% endif %}
 {% endblock 'door-status' %}
 
 <div class="row">

--- a/prism_project/templates/users/users-base.html
+++ b/prism_project/templates/users/users-base.html
@@ -5,6 +5,19 @@
 
 {% block title %}Users Crashpage{% endblock title %}
 
+{% block 'door-status' %}
+    <form method="post" action="/door-toggle">
+        {% csrf_token %}
+        {% if door.status == "open" %}
+            <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
+        {% elif door.status == "closed" %}
+            <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
+        {% else %}
+            <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
+        {% endif %}
+    </form>
+{% endblock 'door-status' %}
+
 {% block 'app-content' %}
     <body>
         <!-- Page Content -->

--- a/prism_project/templates/users/users-base.html
+++ b/prism_project/templates/users/users-base.html
@@ -6,16 +6,18 @@
 {% block title %}Users Crashpage{% endblock title %}
 
 {% block 'door-status' %}
-    <form method="post" action="/door-toggle">
-        {% csrf_token %}
-        {% if door.status == "open" %}
-            <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
-        {% elif door.status == "closed" %}
-            <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
-        {% else %}
-            <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
-        {% endif %}
-    </form>
+    {% if user.is_active and perms.core.change_door %}
+        <form method="post" action="/door-toggle">
+            {% csrf_token %}
+            {% if door.status == "open" %}
+                <input type="submit" class="nav-item btn nav-status open" value="SoHo is {{ door.status }}"/>
+            {% elif door.status == "closed" %}
+                <input type="submit" class="nav-item btn nav-status closed" value="SoHo is {{ door.status }}"/>
+            {% else %}
+                <input type="submit" class="nav-item btn nav-status" value="SoHo is {{ door.status }}"/>
+            {% endif %}
+        </form>
+    {% endif %}
 {% endblock 'door-status' %}
 
 {% block 'app-content' %}

--- a/prism_project/updates/views.py
+++ b/prism_project/updates/views.py
@@ -1,7 +1,9 @@
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.apps import apps
 
 # Load model dynamically to avoid circular import issues
+DoorModel = apps.get_model('core', 'Door')
 UpdateModel = apps.get_model('updates', "Update")
 
 # Create your views here.
@@ -11,6 +13,6 @@ def index(request): # ./updates/
     context = {
         'updates': UpdateModel.objects.order_by('-date_modified'),
         'finalUpdate': UpdateModel.objects.order_by('-date_modified').last(),
+        'door': DoorModel.objects.order_by('-date_modified').first(),
     }
-    print(context)
     return render(request, 'updates/index.html', context)

--- a/prism_project/users/urls.py
+++ b/prism_project/users/urls.py
@@ -4,5 +4,5 @@ from django.views.generic.base import TemplateView
 
 urlpatterns = [
     path('signup/', views.SignUp.as_view(), name='signup'),
-	path('profile/', TemplateView.as_view(template_name='users/profile.html'), name='profile'),
+	path('profile/', views.index, name='profile'),
 ]

--- a/prism_project/users/views.py
+++ b/prism_project/users/views.py
@@ -1,9 +1,22 @@
 from django.urls import reverse_lazy
 from django.views.generic import CreateView
+from django.apps import apps
+from django.shortcuts import render
 
 from .forms import CustomUserCreationForm
+
+PageModel = apps.get_model('pages', "Page")
+DoorModel = apps.get_model('core', 'Door')
 
 class SignUp(CreateView):
     form_class = CustomUserCreationForm
     success_url = reverse_lazy('login')
     template_name = 'users/signup.html'
+
+
+# Take user requests to ./functionName
+def index(request): # ./users/profile
+    context = {
+        'door': DoorModel.objects.order_by('-date_modified').first(),
+    }
+    return render(request, 'users/profile.html', context)


### PR DESCRIPTION
Closes #20.

Adds a button to the door status box on the homepage. The button only appears to users with the core.change_door permission. Pressing the button toggles the door on/off and updates the timestamp. As a bonus, non-homepage views now have a smaller button/indicator in the navbar. The nav button works the same way, toggling the door state.

Picture of the main button:
![Screenshot 2022-07-12 at 08-08-12 PRISM](https://user-images.githubusercontent.com/54556163/178486622-fdcaf9b3-d436-4e32-a4f9-c1f6f10e9681.png)

Picture of the navbutton:
![Screenshot 2022-07-12 at 08-07-10 PRISM](https://user-images.githubusercontent.com/54556163/178486659-55a33c96-9733-4e25-9ba3-6764c25b28b0.png)
